### PR TITLE
:construction_worker: disable test

### DIFF
--- a/src/test/java/com/scc/keycloak/PolicyEnforcerTest.java
+++ b/src/test/java/com/scc/keycloak/PolicyEnforcerTest.java
@@ -1,19 +1,16 @@
 package com.scc.keycloak;
 
-import static io.restassured.RestAssured.given;
-import static org.hamcrest.CoreMatchers.anyOf;
-import static org.hamcrest.CoreMatchers.everyItem;
-import static org.hamcrest.CoreMatchers.is;
-
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.keycloak.representations.AccessTokenResponse;
 
+import io.quarkus.test.junit.DisabledOnNativeImage;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 
 @ExtendWith(KeycloakServer.class)
 @QuarkusTest
+@DisabledOnNativeImage
 public class PolicyEnforcerTest {
 
     private static final String KEYCLOAK_SERVER_URL = System.getProperty("keycloak.url", "http://localhost:8180/auth");


### PR DESCRIPTION
🏗️ désactivation des tests pour la construction de l'image native (erreur connection tcp à la Bdd)